### PR TITLE
feat(HACBS-1259): add python script to upload data to pyxis

### DIFF
--- a/pyxis/create_container_image.py
+++ b/pyxis/create_container_image.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python
+import argparse
+from urllib.parse import quote
+from datetime import datetime
+import json
+import logging
+from typing import Any, Dict, List
+from urllib.parse import urljoin
+
+import pyxis
+
+LOGGER = logging.getLogger("pyxis")
+
+
+def setup_argparser() -> Any:  # pragma: no cover
+    """Setup argument parser
+
+    :return: Initialized argument parser
+    """
+
+    parser = argparse.ArgumentParser(description="ContainerImage resource creator.")
+
+    parser.add_argument(
+        "--pyxis-url",
+        default="https://pyxis.com",
+        help="Base URL for Pyxis container metadata API",
+    )
+    parser.add_argument(
+        "--certified", help="Is the ContainerImage certified?", required=True
+    )
+    parser.add_argument(
+        "--tag",
+        help="The ContainerImage tag name to upload",
+        required=True,
+    )
+    parser.add_argument(
+        "--skopeo-result",
+        help="File with result of `skopeo inspect` running against image"
+        " represented by ContainerImage to be created",
+        required=True,
+    )
+    parser.add_argument(
+        "--is-latest",
+        help="Should the `latest` tag of the ContainerImage be overwritten?",
+        required=True,
+    )
+    parser.add_argument("--verbose", action="store_true", help="Verbose output")
+    return parser
+
+
+def image_already_exists(args, digest: str) -> bool:
+    """Function to check if a containerImage with the given digest
+    already exists in the pyxis instance
+
+    :return: True if one exists, else false
+    """
+
+    # quote is needed to urlparse the quotation marks
+    filter_str = quote(f'docker_image_digest=="{digest}";' f"not(deleted==true)")
+
+    check_url = urljoin(args.pyxis_url, f"v1/images?page_size=1&filter={filter_str}")
+
+    # Get the list of the ContainerImages with given parameters
+    rsp = pyxis.get(check_url)
+    rsp.raise_for_status()
+
+    query_results = rsp.json()["data"]
+
+    if len(query_results) == 0:
+        LOGGER.info("Image with given docker_image_digest doesn't exist yet")
+        return False
+
+    LOGGER.info(
+        "Image with given docker_image_digest already exists."
+        "Skipping the image creation."
+    )
+    if "_id" in query_results[0]:
+        LOGGER.info(f"The image id is: {query_results[0]['_id']}")
+
+    return True
+
+
+def prepare_parsed_data(skopeo_result: Dict[str, Any]) -> Dict[str, Any]:
+    """Function to extract the data this script needs from provided skopeo inspect output
+
+    :return: Dict of tuples containing pertinent data
+    """
+
+    return {
+        "digest": skopeo_result.get("Digest", ""),
+        "docker_version": skopeo_result.get("DockerVersion", ""),
+        "layers": skopeo_result.get("Layers", []),
+        "name": skopeo_result.get("Name", ""),
+        "architecture": skopeo_result.get("Architecture", ""),
+        "env_variables": skopeo_result.get("Env", []),
+    }
+
+
+def create_container_image(args, parsed_data: Dict[str, Any]):
+    """Function to create a new containerImage entry in a pyxis instance"""
+
+    LOGGER.info("Creating new container image")
+
+    date_now = datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%f+00:00")
+
+    if "digest" not in parsed_data:
+        raise Exception(f"Digest was not found in the passed skopeo inspect json")
+    if "name" not in parsed_data:
+        raise Exception(f"Name was not found in the passed skopeo inspect json")
+    docker_image_digest = parsed_data["digest"]
+    # digest isn't accepted in the parsed_data payload to pyxis
+    del parsed_data["digest"]
+    docker_image_registry = parsed_data["name"].split("/")[0]
+    docker_image_repo = parsed_data["name"].split("/", 1)[1]
+    # name isn't accepted in the parsed_data payload to pyxis
+    del parsed_data["name"]
+
+    upload_url = urljoin(args.pyxis_url, f"v1/images")
+    container_image_payload = {
+        "repositories": [
+            {
+                "published": False,
+                "registry": docker_image_registry,
+                "repository": docker_image_repo,
+                "push_date": date_now,
+                "tags": [
+                    {
+                        "added_date": date_now,
+                        "name": args.tag,
+                    },
+                ],
+            }
+        ],
+        "certified": json.loads(args.certified.lower()),
+        "docker_image_digest": docker_image_digest,
+        "image_id": docker_image_digest,
+        "architecture": parsed_data["architecture"],
+        "parsed_data": parsed_data,
+    }
+
+    if args.is_latest == "true":
+        container_image_payload["repositories"][0]["tags"].append(
+            {
+                "added_date": date_now,
+                "name": "latest",
+            }
+        )
+
+    return pyxis.post(upload_url, container_image_payload)
+
+
+def main():  # pragma: no cover
+    """Main func"""
+
+    parser = setup_argparser()
+    args = parser.parse_args()
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    pyxis.setup_logger(level=log_level)
+
+    with open(args.skopeo_result) as json_file:
+        skopeo_result = json.load(json_file)
+
+    parsed_data = prepare_parsed_data(skopeo_result)
+
+    if not image_already_exists(args, parsed_data["digest"]):
+        create_container_image(args, parsed_data)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/pyxis/pyxis.py
+++ b/pyxis/pyxis.py
@@ -1,0 +1,179 @@
+import logging
+import os
+import sys
+from typing import Any, Dict, Optional, Tuple
+from urllib.parse import urljoin
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
+
+import requests
+
+LOGGER = logging.getLogger("operator-cert")
+
+
+def _get_session(pyxis_url: str, auth_required: bool = True) -> requests.Session:
+    """Create a Pyxis http session with auth based on env variables.
+
+    Auth is optional and can be set to use either API key or certificate + key.
+
+    Args:
+        url (str): Pyxis API URL
+        auth_required (bool): Whether authentication should be required for the session
+
+    Raises:
+        Exception: Exception is raised when auth ENV variables are missing.
+
+    :return: Pyxis session
+    """
+    cert_string = "PYXIS_CERT_PATH"
+    key_string = "PYXIS_KEY_PATH"
+    cert = os.environ.get(cert_string)
+    key = os.environ.get(key_string)
+
+    session = requests.Session()
+    add_session_retries(session)
+
+    if not auth_required:
+        LOGGER.debug("Pyxis session without authentication is created")
+        return session
+
+    if cert and key:
+        if os.path.exists(cert) and os.path.exists(key):
+            LOGGER.debug("Pyxis session using cert + key is created")
+            session.cert = (cert, key)
+        else:
+            raise Exception(
+                f"{cert_string} or {key_string} does not point to a file that exists."
+            )
+    else:
+        # cert + key need to be provided using env variable
+        raise Exception(
+            f"No auth details provided for Pyxis. Define {cert_string} + {key_string}"
+        )
+
+    return session
+
+
+def post(url: str, body: Dict[str, Any]) -> Dict[str, Any]:
+    """POST pyxis API request to given URL with given payload
+
+    Args:
+        url (str): Pyxis API URL
+        body (Dict[str, Any]): Request payload
+
+    :return: Pyxis response
+    """
+    session = _get_session(url)
+
+    LOGGER.debug(f"POST Pyxis request: {url}")
+    resp = session.post(url, json=body)
+
+    try:
+        resp.raise_for_status()
+    except requests.HTTPError:
+        LOGGER.exception(
+            f"Pyxis POST query failed with {url} - {resp.status_code} - {resp.text}"
+        )
+        raise
+    return resp.json()
+
+
+def put(url: str, body: Dict[str, Any]) -> Dict[str, Any]:
+    """PUT pyxis API request to given URL with given payload
+
+    Args:
+        url (str): Pyxis API URL
+        body (Dict[str, Any]): Request payload
+
+    :return: Pyxis response
+    """
+    session = _get_session(url)
+
+    LOGGER.debug(f"PATCH Pyxis request: {url}")
+    resp = session.put(url, json=body)
+
+    try:
+        resp.raise_for_status()
+    except requests.HTTPError:
+        LOGGER.exception(
+            f"Pyxis PUT query failed with {url} - {resp.status_code} - {resp.text}"
+        )
+        raise
+    return resp.json()
+
+
+def get(
+    url: str, params: Optional[Dict[str, str]] = None, auth_required: bool = True
+) -> Any:
+    """Pyxis GET request
+
+    Args:
+        url (str): Pyxis URL
+        params (dict): Additional query parameters
+        auth_required (bool): Whether authentication should be required for the session
+
+    :return: Pyxis GET request response
+    """
+    session = _get_session(url, auth_required=auth_required)
+    LOGGER.debug(f"GET Pyxis request url: {url}")
+    LOGGER.debug(f"GET Pyxis request params: {params}")
+    resp = session.get(url, params=params)
+    # Not raising exception for error statuses, because GET request can be used to check
+    # if something exists. We don't want a 404 to cause failures.
+
+    return resp
+
+
+def add_session_retries(
+    session: requests.Session,
+    total: int = 10,
+    backoff_factor: int = 1,
+    status_forcelist: Optional[Tuple[int]] = (408, 500, 502, 503, 504),
+) -> None:
+    """Adds retries to a requests HTTP/HTTPS session.
+    The default values provide exponential backoff for a max wait of ~8.5 mins
+
+    Reference the urllib3 documentation for more details about the kwargs.
+
+    Args:
+        session (Session): A requests session
+        total (int): See urllib3 docs
+        backoff_factor (int): See urllib3 docs
+        status_forcelist (tuple[int]|None): See urllib3 docs
+    """
+    retries = Retry(
+        total=total,
+        backoff_factor=backoff_factor,
+        status_forcelist=status_forcelist,
+        # Don't raise a MaxRetryError for codes in status_forcelist.
+        # This allows for more graceful exception handling using
+        # Response.raise_for_status.
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(max_retries=retries)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+
+
+def setup_logger(level: str = "INFO", log_format: Any = None) -> Any:
+    """Set up and configure 'pyxis' logger.
+    Args:
+        level (str, optional): Logging level. Defaults to "INFO".
+        log_format (Any, optional): Logging message format. Defaults to None.
+    :return: Logger object
+    """
+
+    logger = logging.getLogger("pyxis")
+    logger.propagate = False
+    logger.setLevel(level)
+
+    if log_format is None:
+        log_format = "%(asctime)s [%(name)s] %(levelname)s %(message)s"
+
+    stream_formatter = logging.Formatter(log_format)
+    stream_handler = logging.StreamHandler(sys.stdout)
+    stream_handler.setLevel(level)
+    stream_handler.setFormatter(stream_formatter)
+    logger.addHandler(stream_handler)
+
+    return logger

--- a/pyxis/test_create_container_image.py
+++ b/pyxis/test_create_container_image.py
@@ -1,0 +1,201 @@
+import json
+import pytest
+from datetime import datetime
+from unittest import mock
+from unittest.mock import patch, MagicMock
+
+from create_container_image import (
+    image_already_exists,
+    create_container_image,
+    prepare_parsed_data,
+)
+
+
+mock_pyxis_url = "https://catalog.redhat.com/api/containers/"
+
+
+@patch("create_container_image.pyxis.get")
+def test_image_already_exists(mock_get: MagicMock):
+    # Arrange
+    mock_rsp = MagicMock()
+    mock_get.return_value = mock_rsp
+
+    args = MagicMock()
+    args.pyxis_url = mock_pyxis_url
+    digest = "some_digest"
+
+    # Image already exist
+    mock_rsp.json.return_value = {"data": [{}]}
+
+    # Act
+    exists = image_already_exists(args, digest)
+    # Assert
+    assert exists
+    mock_get.assert_called_with(
+        mock_pyxis_url
+        + "v1/images?page_size=1&filter=docker_image_digest%3D%3D%22some_digest%22%3Bnot%28deleted%3D%3Dtrue%29"
+    )
+
+    # Image doesn't exist
+    mock_rsp.json.return_value = {"data": []}
+
+    # Act
+    exists = image_already_exists(args, digest)
+    # Assert
+    assert not exists
+
+
+@patch("create_container_image.pyxis.post")
+@patch("create_container_image.datetime")
+def test_create_container_image(mock_datetime: MagicMock, mock_post: MagicMock):
+    # Arrange
+    mock_post.return_value = "ok"
+
+    # mock date
+    mock_datetime.now = MagicMock(return_value=datetime(1970, 10, 10, 10, 10, 10))
+
+    args = MagicMock()
+    args.pyxis_url = mock_pyxis_url
+    args.tag = "some_version"
+    args.certified = "false"
+
+    # Act
+    rsp = create_container_image(
+        args,
+        {"architecture": "ok", "digest": "some_digest", "name": "quay.io/some_repo"},
+    )
+
+    # Assert
+    assert rsp == "ok"
+    mock_post.assert_called_with(
+        mock_pyxis_url + "v1/images",
+        {
+            "repositories": [
+                {
+                    "published": False,
+                    "registry": "quay.io",
+                    "repository": "some_repo",
+                    "push_date": "1970-10-10T10:10:10.000000+00:00",
+                    "tags": [
+                        {
+                            "added_date": "1970-10-10T10:10:10.000000+00:00",
+                            "name": "some_version",
+                        }
+                    ],
+                }
+            ],
+            "certified": False,
+            "docker_image_digest": "some_digest",
+            "image_id": "some_digest",
+            "architecture": "ok",
+            "parsed_data": {"architecture": "ok"},
+        },
+    )
+
+
+@patch("create_container_image.pyxis.post")
+@patch("create_container_image.datetime")
+def test_create_container_image_latest(mock_datetime: MagicMock, mock_post: MagicMock):
+    # Arrange
+    mock_post.return_value = "ok"
+
+    # mock date
+    mock_datetime.now = MagicMock(return_value=datetime(1970, 10, 10, 10, 10, 10))
+
+    args = MagicMock()
+    args.pyxis_url = mock_pyxis_url
+    args.tag = "some_version"
+    args.certified = "false"
+    args.is_latest = "true"
+
+    # Act
+    rsp = create_container_image(
+        args,
+        {
+            "architecture": "ok",
+            "digest": "some_digest",
+            "name": "redhat.com/some_repo/foobar",
+        },
+    )
+
+    # Assert
+    assert rsp == "ok"
+    mock_post.assert_called_with(
+        mock_pyxis_url + "v1/images",
+        {
+            "repositories": [
+                {
+                    "published": False,
+                    "registry": "redhat.com",
+                    "repository": "some_repo/foobar",
+                    "push_date": "1970-10-10T10:10:10.000000+00:00",
+                    "tags": [
+                        {
+                            "added_date": "1970-10-10T10:10:10.000000+00:00",
+                            "name": "some_version",
+                        },
+                        {
+                            "added_date": "1970-10-10T10:10:10.000000+00:00",
+                            "name": "latest",
+                        },
+                    ],
+                }
+            ],
+            "certified": False,
+            "docker_image_digest": "some_digest",
+            "image_id": "some_digest",
+            "architecture": "ok",
+            "parsed_data": {"architecture": "ok"},
+        },
+    )
+
+
+def test_create_container_image_no_digest():
+    args = MagicMock()
+
+    with pytest.raises(Exception):
+        create_container_image(
+            args,
+            {
+                "architecture": "ok",
+                "name": "redhat.com/some_repo/foobar",
+            },
+        )
+
+
+def test_create_container_image_no_name():
+    args = MagicMock()
+
+    with pytest.raises(Exception):
+        create_container_image(
+            args,
+            {
+                "architecture": "ok",
+                "digest": "some_digest",
+            },
+        )
+
+
+def test_prepare_parsed_data():
+    # Arrange
+    file_content = {
+        "Digest": "sha:abc",
+        "DockerVersion": "1",
+        "Layers": ["1", "2"],
+        "Name": "quay.io/hacbs-release/release-utils",
+        "Architecture": "test",
+        "Env": ["a=test"],
+    }
+
+    # Act
+    parsed_data = prepare_parsed_data(file_content)
+
+    # Assert
+    assert parsed_data == {
+        "architecture": "test",
+        "digest": "sha:abc",
+        "docker_version": "1",
+        "env_variables": ["a=test"],
+        "layers": ["1", "2"],
+        "name": "quay.io/hacbs-release/release-utils",
+    }

--- a/pyxis/test_pyxis.py
+++ b/pyxis/test_pyxis.py
@@ -1,0 +1,98 @@
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+import pyxis
+from requests import HTTPError, Response, Session
+
+
+@patch("os.path.exists")
+def test_get_session_cert(mock_path_exists: MagicMock, monkeypatch: Any) -> None:
+    mock_path_exists.return_value = True
+    monkeypatch.setenv("PYXIS_CERT_PATH", "/path/to/cert.pem")
+    monkeypatch.setenv("PYXIS_KEY_PATH", "/path/to/key.key")
+    session = pyxis._get_session("test")
+
+    assert session.cert == ("/path/to/cert.pem", "/path/to/key.key")
+
+
+@patch("os.path.exists")
+def test_get_session_cert_not_exist(
+    mock_path_exists: MagicMock, monkeypatch: Any
+) -> None:
+    mock_path_exists.return_value = False
+    monkeypatch.setenv("PYXIS_CERT_PATH", "/path/to/cert.pem")
+    monkeypatch.setenv("PYXIS_KEY_PATH", "/path/to/key.key")
+
+    with pytest.raises(Exception):
+        pyxis._get_session("test")
+
+
+def test_get_session_no_auth(monkeypatch: Any) -> None:
+    session = pyxis._get_session("test", auth_required=False)
+    assert session.cert is None
+
+
+@patch("pyxis._get_session")
+def test_post(mock_session: MagicMock) -> None:
+    mock_session.return_value.post.return_value.json.return_value = {"key": "val"}
+    resp = pyxis.post("https://foo.com/v1/bar", {})
+
+    assert resp == {"key": "val"}
+
+
+@patch("pyxis._get_session")
+def test_post_error(mock_session: MagicMock) -> None:
+    response = Response()
+    response.status_code = 400
+    mock_session.return_value.post.return_value.raise_for_status.side_effect = (
+        HTTPError(response=response)
+    )
+    with pytest.raises(HTTPError):
+        pyxis.post("https://foo.com/v1/bar", {})
+
+
+@patch("pyxis._get_session")
+def test_put(mock_session: MagicMock) -> None:
+    mock_session.return_value.put.return_value.json.return_value = {"key": "val"}
+    resp = pyxis.put("https://foo.com/v1/bar", {})
+
+    assert resp == {"key": "val"}
+
+
+@patch("pyxis._get_session")
+def test_put_error(mock_session: MagicMock) -> None:
+    response = Response()
+    response.status_code = 400
+    mock_session.return_value.put.return_value.raise_for_status.side_effect = HTTPError(
+        response=response
+    )
+    with pytest.raises(HTTPError):
+        pyxis.put("https://foo.com/v1/bar", {})
+
+
+@patch("pyxis._get_session")
+def test_get(mock_session: MagicMock) -> None:
+    mock_session.return_value.get.return_value = {"key": "val"}
+    resp = pyxis.get("https://foo.com/v1/bar")
+
+    assert resp == {"key": "val"}
+
+
+def test_add_session_retries() -> None:
+    status_forcelist = (404, 503)
+    total = 3
+    backoff_factor = 0.5
+    session = Session()
+    pyxis.add_session_retries(
+        session,
+        total=total,
+        backoff_factor=backoff_factor,
+        status_forcelist=status_forcelist,
+    )
+    assert session.adapters["http://"].max_retries.total == total
+    assert session.adapters["http://"].max_retries.backoff_factor == backoff_factor
+    assert session.adapters["http://"].max_retries.status_forcelist == status_forcelist
+    assert session.adapters["https://"].max_retries.total == total
+    assert session.adapters["https://"].max_retries.backoff_factor == backoff_factor
+    assert session.adapters["https://"].max_retries.status_forcelist == status_forcelist


### PR DESCRIPTION
This commit adds a reworked version of the create-container-image script from the openshift ecosystem team to enable pushing container image metadata to pyxis.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>