### PR TITLE
fix: rebuild image for any change to the repo

### DIFF
--- a/.github/workflows/dockerfile_push.yaml
+++ b/.github/workflows/dockerfile_push.yaml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'Dockerfile'
 jobs:
   push-dockerfile:
     name: Push dockerfile


### PR DESCRIPTION
If the contents of this repo change, the image should be rebuilt so that there is an image available with the updated repo changes. It should not only be built on Dockerfile changes.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>