### PR TITLE
fix(HACBS-1261): ensure pyxis image was successfully pushed

### DIFF
--- a/pyxis/create_container_image.py
+++ b/pyxis/create_container_image.py
@@ -165,6 +165,10 @@ def main():  # pragma: no cover
     if not image_already_exists(args, parsed_data["digest"]):
         create_container_image(args, parsed_data)
 
+    # Make sure image is now available
+    if not image_already_exists(args, parsed_data["digest"]):
+        raise Exception("Image metadata was not successfully added to Pyxis.")
+
 
 if __name__ == "__main__":  # pragma: no cover
     main()


### PR DESCRIPTION
After the post is done to pyxis, execute a get to make sure the image metadata was successfully added. This also has the added benefit of the containerImageID being printed out in all scenarios.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>