### PR TITLE
fix(HACBS-1676): replace cleanup annotation

### DIFF
--- a/copy-application.sh
+++ b/copy-application.sh
@@ -7,7 +7,7 @@ LONG_OPTS=applications:,all,help
 OPTS=$(getopt --alternative --name copy-application --options $SHORT_OPTS --longoptions $LONG_OPTS -- "$@")
 
 CLEANUP_ANNOTATIONS=(
-    "\"com.redhat.appstudio/component-initial-build-processed\"": "\"true\""
+    "\"appstudio.openshift.io/component-initial-build\"": "\"true\""
 )
 CLEANUP_KEYS=(
     ".metadata.finalizers",


### PR DESCRIPTION
The annotation got updated recently by the build service and
this PR satisfies the [new changes](https://github.com/redhat-appstudio/build-service/pull/103)
to make the service forward/backward compatible.

Signed-off-by: Happy <hbhati@redhat.com>