### PR TITLE
fix: update github workflow to remove warnings

### DIFF
--- a/.github/workflows/build_and_push_image.yaml
+++ b/.github/workflows/build_and_push_image.yaml
@@ -1,30 +1,31 @@
-name: Push Dockerfile to Quay
+name: Build and push image
 on:
   push:
     branches:
       - main
 jobs:
-  push-dockerfile:
-    name: Push dockerfile
+  build-and-push-image:
+    name: Build and push image
     runs-on: ubuntu-20.04
     env:
       QUAY_ORG: hacbs-release
       QUAY_REPO: release-utils
     steps:
       - name: Check out source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Login to Quay
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_ROBOT_USER }}
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
-      - name: Build container and push it to Quay
-        uses: docker/build-push-action@v2
+      - name: Build image and push it to Quay
+        uses: docker/build-push-action@v4
         with:
           context: .
           push: true
           file: Dockerfile
           tags: |
             quay.io/${{ env.QUAY_ORG }}/${{ env.QUAY_REPO }}:main
+            quay.io/${{ env.QUAY_ORG }}/${{ env.QUAY_REPO }}:latest
             quay.io/${{ env.QUAY_ORG }}/${{ env.QUAY_REPO }}:${{ github.sha }}


### PR DESCRIPTION
There were some warnings, mainly that the action
versions we were using were using Node.js 12 which is now deprecated.

I also renamed the workflow to more accurately reflect what it's doing.

Also, I'm adding the latest tag for the image. It's nice to have since it's the default when pulling the image without specifying a tag.

Signed-off-by: Martin Malina <mmalina@redhat.com>