### PR TITLE
fix: fix linting errors

### DIFF
--- a/pyxis/create_container_image
+++ b/pyxis/create_container_image
@@ -4,12 +4,12 @@ from urllib.parse import quote
 from datetime import datetime
 import json
 import logging
-from typing import Any, Dict, List
+from typing import Any, Dict
 from urllib.parse import urljoin
 
 import pyxis
 
-LOGGER = logging.getLogger("pyxis")
+LOGGER = logging.getLogger("create_container_image")
 
 
 def setup_argparser() -> Any:  # pragma: no cover
@@ -106,9 +106,9 @@ def create_container_image(args, parsed_data: Dict[str, Any]):
     date_now = datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%f+00:00")
 
     if "digest" not in parsed_data:
-        raise Exception(f"Digest was not found in the passed skopeo inspect json")
+        raise Exception("Digest was not found in the passed skopeo inspect json")
     if "name" not in parsed_data:
-        raise Exception(f"Name was not found in the passed skopeo inspect json")
+        raise Exception("Name was not found in the passed skopeo inspect json")
     docker_image_digest = parsed_data["digest"]
     # digest isn't accepted in the parsed_data payload to pyxis
     del parsed_data["digest"]
@@ -117,7 +117,7 @@ def create_container_image(args, parsed_data: Dict[str, Any]):
     # name isn't accepted in the parsed_data payload to pyxis
     del parsed_data["name"]
 
-    upload_url = urljoin(args.pyxis_url, f"v1/images")
+    upload_url = urljoin(args.pyxis_url, "v1/images")
     container_image_payload = {
         "repositories": [
             {

--- a/pyxis/pyxis.py
+++ b/pyxis/pyxis.py
@@ -2,13 +2,12 @@ import logging
 import os
 import sys
 from typing import Any, Dict, Optional, Tuple
-from urllib.parse import urljoin
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
+from urllib3.util.retry import Retry
 
 import requests
 
-LOGGER = logging.getLogger("operator-cert")
+LOGGER = logging.getLogger("pyxis")
 
 
 def _get_session(pyxis_url: str, auth_required: bool = True) -> requests.Session:
@@ -102,9 +101,7 @@ def put(url: str, body: Dict[str, Any]) -> Dict[str, Any]:
     return resp.json()
 
 
-def get(
-    url: str, params: Optional[Dict[str, str]] = None, auth_required: bool = True
-) -> Any:
+def get(url: str, params: Optional[Dict[str, str]] = None, auth_required: bool = True) -> Any:
     """Pyxis GET request
 
     Args:
@@ -128,7 +125,7 @@ def add_session_retries(
     session: requests.Session,
     total: int = 10,
     backoff_factor: int = 1,
-    status_forcelist: Optional[Tuple[int]] = (408, 500, 502, 503, 504),
+    status_forcelist: Optional[Tuple[int, ...]] = (408, 500, 502, 503, 504),
 ) -> None:
     """Adds retries to a requests HTTP/HTTPS session.
     The default values provide exponential backoff for a max wait of ~8.5 mins
@@ -155,10 +152,10 @@ def add_session_retries(
     session.mount("https://", adapter)
 
 
-def setup_logger(level: str = "INFO", log_format: Any = None) -> Any:
+def setup_logger(level: int = logging.INFO, log_format: Any = None) -> Any:
     """Set up and configure 'pyxis' logger.
     Args:
-        level (str, optional): Logging level. Defaults to "INFO".
+        level (str, optional): Logging level. Defaults to logging.INFO.
         log_format (Any, optional): Logging message format. Defaults to None.
     :return: Logger object
     """


### PR DESCRIPTION
There were a couple of issues:

- An unused import
- A wrong type used for logging level - it's set by constants which are int
- f-strings without any placeholders

We should really have linters run as part of a PR workflow here. I created a story for it: https://issues.redhat.com/browse/HACBS-1772

Signed-off-by: Martin Malina <mmalina@redhat.com>