### PR TITLE
chore(HACBS-1717) New script to setup quay secret

### DIFF
--- a/setup-quay-push-secret.sh
+++ b/setup-quay-push-secret.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# This script collects input needed to create a dockerconfigjson secret
+# and link it to a newly created service account using SPI
+
+# Defaults
+#
+export TARGET_NAMESPACE_DEFAULT=managed-release-team-tenant
+export QUAY_ORG_URL_EXAMPLE=https://quay.io/repository/hacbs-release-tests
+export SERVICE_ACCOUNT_DEFAULT=release-service-account
+
+export token=$(oc whoami -t)
+
+if [ -z "${token}" ]; then
+  echo "Error: Not logged in to cluster"
+  exit 1
+fi
+
+read -p "Please enter the target workspace: [${TARGET_NAMESPACE_DEFAULT}] " target_namespace
+target_namespace=${target_namespace:-${TARGET_NAMESPACE_DEFAULT}}
+
+read -p "Please enter the service account name: [${SERVICE_ACCOUNT_DEFAULT}] " service_account
+service_account=${service_account:-${SERVICE_ACCOUNT_DEFAULT}}
+
+read -p "Please enter a quay organization URL where to push content to: [${QUAY_ORG_URL_EXAMPLE}] " quay_org_url
+quay_org_url=${quay_org_url:-${QUAY_ORG_URL_EXAMPLE}}
+
+read -p "Please enter your quay robot username: [] " quay_oauth_user
+
+read -s -p "Please enter your quay robot token: [] " quay_oauth_token
+
+export binding_name=binding-dockerconfigjson-$$
+export robot_secret_name=robot-account-pull-secret-$$
+
+echo ""
+echo "Going to create SPIAccessTokenBinding in $target_namespace"
+
+cat <<EOF | kubectl apply -n $target_namespace -f -
+apiVersion: appstudio.redhat.com/v1beta1
+kind: SPIAccessTokenBinding
+metadata:
+  name: ${binding_name}
+spec:
+  permissions:
+    required:
+      - type: rw
+        area: registry
+      - type: rw
+        area: registryMetadata
+  repoUrl: $quay_org_url
+  secret:
+    type: kubernetes.io/dockerconfigjson
+    name: ${robot_secret_name}
+    linkedTo:
+      - serviceAccount:
+          managed:
+            name: ${service_account}
+EOF
+echo "Binding created"
+sleep 3
+echo "Waiting for AwaitingTokenData phase"
+kubectl wait --for=jsonpath='{.status.phase}'=AwaitingTokenData Spiaccesstokenbinding/${binding_name} -n $target_namespace --timeout=60s
+
+if [ $? -ne 0 ] ; then
+  echo "Error: could get token data after 60s. Verify your input."
+  exit 1
+fi
+
+upload_url=$(kubectl get spiaccesstokenbinding/${binding_name} -n $target_namespace -o json | jq -r .status.uploadUrl)
+echo "Upload url: ${upload_url}"
+curl --insecure \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: bearer $token" \
+  -d "{ \"access_token\": \"${quay_oauth_token}\" ,  \"username\": \"${quay_oauth_user}\" }" \
+  ${upload_url}
+echo "Waiting for Injected phase"
+kubectl wait --for=jsonpath='{.status.phase}'=Injected Spiaccesstokenbinding/${binding_name} -n $target_namespace --timeout=60s
+
+if [ $? -ne 0 ] ; then
+  echo "Error: could verify if secret was injected after 60s. Verify your input."
+  exit 1
+fi
+
+linked_secret_name=$(kubectl get spiaccesstokenbinding/${binding_name} -n  ${target_namespace}   -o  json | jq -r  .status.syncedObjectRef.name)
+echo "Linked secret: ${linked_secret_name}"


### PR DESCRIPTION
Signed-off-by: Scott Hebert <shebert@redhat.com>

% ./setup-quay-push-secret.sh

```
Please enter the target workspace: [managed-release-team-tenant] temp4
Please enter the service account name: [release-service-account] 
Please enter the quay repo URL: [https://quay.io/repository/hacbs-release-tests/shebert-dc-metrocmap] 
Please enter your quay robot username: [] scoheb
Please enter your quay robot token: [] 
Going to create SPIAccessTokenBinding in temp4
spiaccesstokenbinding.appstudio.redhat.com/binding-dockerconfigjson-176186 created
Binding created
Waiting for AwaitingTokenData phase
spiaccesstokenbinding.appstudio.redhat.com/binding-dockerconfigjson-176186 condition met
Upload url: https://spi-oauth-spi-system.apps.scott-test-1717.clusters.stonesoupengineering.com/token/temp4/generated-spi-access-token-rr967
Waiting for Injected phase
spiaccesstokenbinding.appstudio.redhat.com/binding-dockerconfigjson-176186 condition met
Linked secret: robot-account-pull-secret-176186
```

% oc get sa/release-service-account -n temp3

```
NAME                      SECRETS   AGE
release-service-account   2         5m40s
```

% oc get sa/release-service-account -n temp3 -o yaml

```
apiVersion: v1
imagePullSecrets:
- name: release-service-account-dockercfg-j2c8g
kind: ServiceAccount
metadata:
  annotations:
    spi.appstudio.redhat.com/linked-access-token-binding: binding-dockerconfigjson-176186
  creationTimestamp: "2023-02-10T03:35:58Z"
  labels:
    spi.appstudio.redhat.com/managed-by-binding: binding-dockerconfigjson-176186
  name: release-service-account
  namespace: temp3
  resourceVersion: "13946611"
  uid: f689269b-05f2-4f30-8583-8a48ef89052d
secrets:
- name: release-service-account-dockercfg-j2c8g
- name: robot-account-pull-secret-176186
```
