### PR TITLE
fix(HACBS-1772): fix current flake8 errors

### DIFF
--- a/pyxis/test_create_container_image.py
+++ b/pyxis/test_create_container_image.py
@@ -1,7 +1,5 @@
-import json
 import pytest
 from datetime import datetime
-from unittest import mock
 from unittest.mock import patch, MagicMock
 
 from create_container_image import (
@@ -33,7 +31,8 @@ def test_image_already_exists(mock_get: MagicMock):
     assert exists
     mock_get.assert_called_with(
         mock_pyxis_url
-        + "v1/images?page_size=1&filter=docker_image_digest%3D%3D%22some_digest%22%3Bnot%28deleted%3D%3Dtrue%29"
+        + "v1/images?page_size=1&filter="
+        + "docker_image_digest%3D%3D%22some_digest%22%3Bnot%28deleted%3D%3Dtrue%29"
     )
 
     # Image doesn't exist


### PR DESCRIPTION
I used a line length of 88 for checking (flake8 default is 79, but black defaults to 88 and we are also using black).