### PR TITLE
Add flake8 action and set max line length to 95

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 95

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,5 +9,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: psf/black@stable
+      - name: Check out repo
+        uses: actions/checkout@v3
+      - name: Black Lint
+        uses: psf/black@stable
+        with:
+          options: "--line-length 95"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,5 +13,9 @@ jobs:
         uses: actions/checkout@v3
       - name: Black Lint
         uses: psf/black@stable
+      - name: Setup python environment for flake8 check
+        uses: actions/setup-python@v4
         with:
-          options: "--line-length 95"
+          python-version: "3.9" # Same as in Dockerfile
+      - name: flake8 Lint
+        uses: py-actions/flake8@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 95

--- a/pyxis/pyxis.py
+++ b/pyxis/pyxis.py
@@ -101,9 +101,7 @@ def put(url: str, body: Dict[str, Any]) -> Dict[str, Any]:
     return resp.json()
 
 
-def get(
-    url: str, params: Optional[Dict[str, str]] = None, auth_required: bool = True
-) -> Any:
+def get(url: str, params: Optional[Dict[str, str]] = None, auth_required: bool = True) -> Any:
     """Pyxis GET request
 
     Args:

--- a/pyxis/test_pyxis.py
+++ b/pyxis/test_pyxis.py
@@ -17,9 +17,7 @@ def test_get_session_cert(mock_path_exists: MagicMock, monkeypatch: Any) -> None
 
 
 @patch("os.path.exists")
-def test_get_session_cert_not_exist(
-    mock_path_exists: MagicMock, monkeypatch: Any
-) -> None:
+def test_get_session_cert_not_exist(mock_path_exists: MagicMock, monkeypatch: Any) -> None:
     mock_path_exists.return_value = False
     monkeypatch.setenv("PYXIS_CERT_PATH", "/path/to/cert.pem")
     monkeypatch.setenv("PYXIS_KEY_PATH", "/path/to/key.key")
@@ -45,8 +43,8 @@ def test_post(mock_session: MagicMock) -> None:
 def test_post_error(mock_session: MagicMock) -> None:
     response = Response()
     response.status_code = 400
-    mock_session.return_value.post.return_value.raise_for_status.side_effect = (
-        HTTPError(response=response)
+    mock_session.return_value.post.return_value.raise_for_status.side_effect = HTTPError(
+        response=response
     )
     with pytest.raises(HTTPError):
         pyxis.post("https://foo.com/v1/bar", {})


### PR DESCRIPTION
This PR has two commits. One changes the max line length for black and flake8 in this repo to be 95 (and adds config files doing that). The second adds a github action to enforce flake8 formatting