### PR TITLE
fix(HACBS-1803): fix current pytest errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,7 @@ ENV HOME=/tekton/home
 # The ~ dir seems to be mounted over in tekton tasks, so put in /home
 RUN git clone https://github.com/hacbs-release/release-utils /home/release-utils
 
+# Copy the create_container_image script so we can use it without extension in release-bundles
+COPY /home/release-utils/pyxis/create_container_image.py /home/release-utils/pyxis/create_container_image
+
 ENV PATH=$PATH:/home/release-utils/pyxis

--- a/pyxis/create_container_image.py
+++ b/pyxis/create_container_image.py
@@ -25,9 +25,7 @@ def setup_argparser() -> Any:  # pragma: no cover
         default="https://pyxis.com",
         help="Base URL for Pyxis container metadata API",
     )
-    parser.add_argument(
-        "--certified", help="Is the ContainerImage certified?", required=True
-    )
+    parser.add_argument("--certified", help="Is the ContainerImage certified?", required=True)
     parser.add_argument(
         "--tag",
         help="The ContainerImage tag name to upload",
@@ -71,15 +69,12 @@ def image_already_exists(args, digest: str) -> bool:
         return False
 
     LOGGER.info(
-        "Image with given docker_image_digest already exists."
-        "Skipping the image creation."
+        "Image with given docker_image_digest already exists." "Skipping the image creation."
     )
     if "_id" in query_results[0]:
         LOGGER.info(f"The image id is: {query_results[0]['_id']}")
     else:
-        raise Exception(
-            "Image metadata was found in Pyxis, but the id key was missing."
-        )
+        raise Exception("Image metadata was found in Pyxis, but the id key was missing.")
 
     return True
 

--- a/pyxis/test_create_container_image.py
+++ b/pyxis/test_create_container_image.py
@@ -22,8 +22,8 @@ def test_image_already_exists(mock_get: MagicMock):
     args.pyxis_url = mock_pyxis_url
     digest = "some_digest"
 
-    # Image already exist
-    mock_rsp.json.return_value = {"data": [{}]}
+    # Image already exists
+    mock_rsp.json.return_value = {"data": [{"_id": 0}]}
 
     # Act
     exists = image_already_exists(args, digest)
@@ -47,8 +47,8 @@ def test_image_already_exists(mock_get: MagicMock):
 @patch("create_container_image.pyxis.post")
 @patch("create_container_image.datetime")
 def test_create_container_image(mock_datetime: MagicMock, mock_post: MagicMock):
-    # Arrange
-    mock_post.return_value = "ok"
+    # Mock an _id in the response for logger check
+    mock_post.return_value = {"_id": 0}
 
     # mock date
     mock_datetime.now = MagicMock(return_value=datetime(1970, 10, 10, 10, 10, 10))
@@ -59,13 +59,12 @@ def test_create_container_image(mock_datetime: MagicMock, mock_post: MagicMock):
     args.certified = "false"
 
     # Act
-    rsp = create_container_image(
+    create_container_image(
         args,
         {"architecture": "ok", "digest": "some_digest", "name": "quay.io/some_repo"},
     )
 
     # Assert
-    assert rsp == "ok"
     mock_post.assert_called_with(
         mock_pyxis_url + "v1/images",
         {
@@ -95,8 +94,8 @@ def test_create_container_image(mock_datetime: MagicMock, mock_post: MagicMock):
 @patch("create_container_image.pyxis.post")
 @patch("create_container_image.datetime")
 def test_create_container_image_latest(mock_datetime: MagicMock, mock_post: MagicMock):
-    # Arrange
-    mock_post.return_value = "ok"
+    # Mock an _id in the response for logger check
+    mock_post.return_value = {"_id": 0}
 
     # mock date
     mock_datetime.now = MagicMock(return_value=datetime(1970, 10, 10, 10, 10, 10))
@@ -108,7 +107,7 @@ def test_create_container_image_latest(mock_datetime: MagicMock, mock_post: Magi
     args.is_latest = "true"
 
     # Act
-    rsp = create_container_image(
+    create_container_image(
         args,
         {
             "architecture": "ok",
@@ -118,7 +117,6 @@ def test_create_container_image_latest(mock_datetime: MagicMock, mock_post: Magi
     )
 
     # Assert
-    assert rsp == "ok"
     mock_post.assert_called_with(
         mock_pyxis_url + "v1/images",
         {


### PR DESCRIPTION
This PR includes renaming `create_container_image` back to have its .py suffix. This is because the imports don't work properly without it. There are workarounds (see https://stackoverflow.com/questions/2601047/import-a-python-module-without-the-py-extension) but I think it would be nice to just put the suffix back. Open to discussion on it