### PR TITLE
fix: use RUN cp instead of COPY in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,6 @@ ENV HOME=/tekton/home
 RUN git clone https://github.com/hacbs-release/release-utils /home/release-utils
 
 # Copy the create_container_image script so we can use it without extension in release-bundles
-COPY /home/release-utils/pyxis/create_container_image.py /home/release-utils/pyxis/create_container_image
+RUN cp /home/release-utils/pyxis/create_container_image.py /home/release-utils/pyxis/create_container_image
 
 ENV PATH=$PATH:/home/release-utils/pyxis


### PR DESCRIPTION
`COPY` uses the current directory as its src, unlike `cp`